### PR TITLE
Fix DEST protocol validation and add tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ const log = {
 
 // Load destinations from environment variables
 function loadDestinations() {
+  // Validate DEST_<NAME>_PROTOCOL values (only "http" or "https" allowed)
+  const allowedProtocols = new Set(['http', 'https']);
   const destinations = {};
   const envKeys = Object.keys(process.env);
   const destNames = new Set();
@@ -34,6 +36,11 @@ function loadDestinations() {
   // Build destination objects with API keys
   destNames.forEach(name => {
     const protocol = process.env[`DEST_${name}_PROTOCOL`] || 'https';
+    // Validate protocol value
+    if (!allowedProtocols.has(protocol.toLowerCase())) {
+      log.warn(`Invalid protocol "${protocol}" for destination "${name}". Skipping this destination.`);
+      return; // skip adding this destination
+    }
     const host = process.env[`DEST_${name}_HOST`] || 'localhost';
     const port = process.env[`DEST_${name}_PORT`] || (protocol === 'https' ? '443' : '8080');
     const apiKey = process.env[`${name}_API_KEY`] || null;
@@ -205,6 +212,13 @@ app.use(authenticateRouter);
 app.use(createRoutingProxy());
 
 // Start server
-app.listen(PORT, () => {
-  log.info(`✅ Server ready on http://localhost:${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    log.info(`✅ Server ready on http://localhost:${PORT}`);
+  });
+}
+
+// Export for testing
+module.exports = { loadDestinations, app };
+
+

--- a/package.json
+++ b/package.json
@@ -4,12 +4,17 @@
   "description": "API Router that forwards requests to another host/port",
   "main": "index.js",
   "scripts": {
+    "test": "jest",
     "start": "node index.js",
     "dev": "node --watch index.js"
   },
   "dependencies": {
+
     "dotenv": "^17.3.1",
     "express": "^4.18.2",
     "http-proxy-middleware": "^2.0.6"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
   }
 }

--- a/test/loadDestinations.test.js
+++ b/test/loadDestinations.test.js
@@ -1,0 +1,21 @@
+const { loadDestinations } = require('..');
+
+describe('loadDestinations validation', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  afterEach(() => {
+    // Restore original env
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  test('skips destinations with invalid protocol', () => {
+    process.env.DEST_VALID_PROTOCOL = 'http';
+    process.env.DEST_VALID_HOST = 'example.com';
+    process.env.DEST_INVALID_PROTOCOL = 'ftp'; // invalid
+    process.env.DEST_INVALID_HOST = 'bad.com';
+    const destinations = loadDestinations();
+    expect(destinations).toHaveProperty('valid');
+    expect(destinations).not.toHaveProperty('invalid');
+    expect(destinations.valid.protocol).toBe('http');
+  });
+});


### PR DESCRIPTION
## Description

Implemented validation for `DEST_<NAME>_PROTOCOL` environment variables, ensuring only `http` or `https` are accepted. Invalid protocols are logged and skipped. Added Jest test to verify this behavior. Exported `loadDestinations` and `app` for testing and guarded server start to prevent Jest hangs. Updated `package.json` with a test script and `jest` dev dependency.

## Changes
- Added protocol whitelist and validation in `loadDestinations`.
- Exported `loadDestinations` and `app`.
- Wrapped server start in `require.main === module` guard.
- Added Jest test `test/loadDestinations.test.js`.
- Updated `package.json` scripts and devDependencies.

## Benefits
- Prevents misconfiguration with unsupported protocols.
- Improves testability of the module.
- Provides automated test coverage for the new validation.

## Labels

bug, improvement, testing